### PR TITLE
Fixed for apps that have USE_TZ set to False.

### DIFF
--- a/notifications/models.py
+++ b/notifications/models.py
@@ -175,7 +175,7 @@ def notify_handler(verb, **kwargs):
         verb=unicode(verb),
         public=bool(kwargs.pop('public', True)),
         description=kwargs.pop('description', None),
-        timestamp=kwargs.pop('timestamp', datetime.datetime.utcnow().replace(tzinfo=utc))
+        timestamp=kwargs.pop('timestamp', now)
     )
 
     for opt in ('target', 'action_object'):


### PR DESCRIPTION
Use `django.utils.timezone.now` instead of `datetime.datetime.utcnow().replace(tzinfo=utc)` in models.py.
