### PR TITLE
Allow setting notification levels

### DIFF
--- a/notifications/models.py
+++ b/notifications/models.py
@@ -173,6 +173,7 @@ def notify_handler(verb, **kwargs):
         actor_content_type=ContentType.objects.get_for_model(actor),
         actor_object_id=actor.pk,
         verb=unicode(verb),
+        level=kwargs.pop('level', 'info'),
         public=bool(kwargs.pop('public', True)),
         description=kwargs.pop('description', None),
         timestamp=kwargs.pop('timestamp', now())

--- a/notifications/signals.py
+++ b/notifications/signals.py
@@ -2,5 +2,5 @@ from django.dispatch import Signal
 
 notify = Signal(providing_args=[
     'recipient', 'actor', 'verb', 'action_object', 'target', 'description',
-    'timestamp'
+    'timestamp', 'level'
 ])


### PR DESCRIPTION
Allow setting a notification level ('info', 'warning', 'success' or 'error') while emitting the notify signal.