### PR TITLE
use different `now` function according to the `USE_TZ` setting

### DIFF
--- a/notifications/models.py
+++ b/notifications/models.py
@@ -11,11 +11,14 @@ from notifications.signals import notify
 
 from model_utils import managers, Choices
 
-try:
-    from django.utils import timezone
-    now = timezone.now
-except ImportError:
-    now = datetime.datetime.now
+now = datetime.datetime.now
+if getattr(settings, 'USE_TZ'):
+    try:
+        from django.utils import timezone
+        now = timezone.now
+    except ImportError:
+        pass
+
 
 class NotificationQuerySet(models.query.QuerySet):
     

--- a/notifications/tests.py
+++ b/notifications/tests.py
@@ -4,13 +4,40 @@ when you run "manage.py test".
 
 Replace this with more appropriate tests for your application.
 """
+import datetime
 
 from django.test import TestCase
+from django.test.utils import override_settings
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.utils.timezone import utc
 
 
-class SimpleTest(TestCase):
-    def test_basic_addition(self):
-        """
-        Tests that 1 + 1 always equals 2.
-        """
-        self.assertEqual(1 + 1, 2)
+from notifications import notify
+from notifications.models import Notification
+
+
+class NotificationTest(TestCase):
+
+    def setUp(self):
+        settings.USE_TZ = True
+
+    @override_settings(USE_TZ=True)
+    @override_settings(TIME_ZONE='Asia/Shanghai')
+    def test_use_timezone(self):
+        from_user = User.objects.create(username="from", password="pwd", email="example@example.com")
+        to_user = User.objects.create(username="to", password="pwd", email="example@example.com")
+        notify.send(from_user, recipient=to_user, verb='commented', action_object=from_user)
+        notification = Notification.objects.get(recipient=to_user)
+        delta = datetime.datetime.utcnow().replace(tzinfo=utc) - notification.timestamp
+        self.assertTrue(delta.seconds >= 8 * 60 * 59)
+
+    @override_settings(USE_TZ=False)
+    @override_settings(TIME_ZONE='Asia/Shanghai')
+    def test_disable_timezone(self):
+        from_user = User.objects.create(username="from2", password="pwd", email="example@example.com")
+        to_user = User.objects.create(username="to2", password="pwd", email="example@example.com")
+        notify.send(from_user, recipient=to_user, verb='commented', action_object=from_user)
+        notification = Notification.objects.get(recipient=to_user)
+        delta = datetime.datetime.utcnow() - notification.timestamp
+        self.assertTrue(delta.seconds < 60)


### PR DESCRIPTION
Hi, I'm using django-notifications in my project and it's a great django app. But I found that there was an exception throwed(see below) when I set `USE_TZ = False` in settings.py. I think there should be a test for USE_TZ when using django's `now` function or python's built-in `now` function. So I fixed this issue and made this pull request. Please merge this fork. Thanks.

The exception's stack trace:

```
  File "/usr/local/lib/python2.7/dist-packages/django/dispatch/dispatcher.py", line 172, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/usr/local/lib/python2.7/dist-packages/notifications/models.py", line 191, in notify_handler
    newnotify.save()
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/base.py", line 463, in save
    self.save_base(using=using, force_insert=force_insert, force_update=force_update)
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/base.py", line 551, in save_base
    result = manager._insert([self], fields=fields, return_id=update_pk, using=using, raw=raw)
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/manager.py", line 203, in _insert
    return insert_query(self.model, objs, fields, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/query.py", line 1593, in insert_query
    return query.get_compiler(using=using).execute_sql(return_id)
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/sql/compiler.py", line 911, in execute_sql
    for sql, params in self.as_sql():
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/sql/compiler.py", line 872, in as_sql
    for obj in self.query.objs
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/fields/__init__.py", line 292, in get_db_prep_save
    prepared=False)
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/fields/__init__.py", line 817, in get_db_prep_value
    return connection.ops.value_to_db_datetime(value)
  File "/usr/local/lib/python2.7/dist-packages/django/db/backends/mysql/base.py", line 283, in value_to_db_datetime
    raise ValueError("MySQL backend does not support timezone-aware datetimes when USE_TZ is False.")
ValueError: MySQL backend does not support timezone-aware datetimes when USE_TZ is False.
```
