### PR TITLE
can't build whl package due to setup.py referencing packaged to be installed

### DIFF
--- a/notifications/__init__.py
+++ b/notifications/__init__.py
@@ -1,3 +1,14 @@
+try:
+    from notifications.signals import notify
+except ImportError:
+    pass
+
+try:
+    from notifications.urls import urlpatterns
+    urls = (urlpatterns, 'notifications', 'notifications')
+except ImportError:
+    pass
+
 __version_info__ = {
     'major': 0,
     'minor': 6,
@@ -18,15 +29,3 @@ def get_version(release_level=True):
 
 
 __version__ = get_version()
-
-try:
-    from notifications.signals import notify
-except ImportError:
-    pass
-
-try:
-    from notifications.urls import urlpatterns
-    urls = (urlpatterns, 'notifications', 'notifications')
-except ImportError:
-    pass
-

--- a/notifications/__init__.py
+++ b/notifications/__init__.py
@@ -1,14 +1,3 @@
-try:
-    from notifications.signals import notify
-except ImportError:
-    pass
-
-try:
-    from notifications.urls import urlpatterns
-    urls = (urlpatterns, 'notifications', 'notifications')
-except ImportError:
-    pass
-
 __version_info__ = {
     'major': 0,
     'minor': 6,
@@ -29,3 +18,15 @@ def get_version(release_level=True):
 
 
 __version__ = get_version()
+
+try:
+    from notifications.signals import notify
+except ImportError:
+    pass
+
+try:
+    from notifications.urls import urlpatterns
+    urls = (urlpatterns, 'notifications', 'notifications')
+except ImportError:
+    pass
+

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
 from django.db import models
-from django.utils.timezone import utc
+from django.core.exceptions import ImproperlyConfigured
 from .utils import id2slug
 
 from notifications.signals import notify

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 from distutils.core import setup
-from notifications import __version__
 
 setup(name='django-notifications-hq',
-      version=__version__,
+      version=0.6,
       description='GitHub notifications alike app for Django.',
       long_description=open('README.rst').read(),
       author='Brant Young',


### PR DESCRIPTION
setup.py shouldn't refer to the module that setup.py is meant to be installing, since the user may not have the dependencies installed yet!

This breaks pip wheel functionality:

```
pip wheel django-notifications-hq
Downloading/unpacking django-notifications-hq
  Downloading django-notifications-hq-0.6.0.tar.gz
  Running setup.py egg_info for package django-notifications-hq
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/tmp/pip_build_joel/django-notifications-hq/setup.py", line 2, in <module>
        from notifications import __version__
      File "notifications/__init__.py", line 7, in <module>
        from notifications.urls import urlpatterns
      File "notifications/urls.py", line 5, in <module>
        urlpatterns = patterns('notifications.views',
    NameError: name 'patterns' is not defined
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/tmp/pip_build_joel/django-notifications-hq/setup.py", line 2, in <module>

    from notifications import __version__

  File "notifications/__init__.py", line 7, in <module>

    from notifications.urls import urlpatterns

  File "notifications/urls.py", line 5, in <module>

    urlpatterns = patterns('notifications.views',

NameError: name 'patterns' is not defined
```

Sorry for the extra commits in the PR. I was attempting to keep using the version defined in `notifications/__init__.py` before realising this is a bad thing and very few if any other setup.py files refer to the modules they install.