### PR TITLE
Add max version for django-model-utils dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='django-notifications-hq',
       url='http://github.com/brantyoung/django-notifications',
       install_requires=[
           'django>=1.4',
-          'django-model-utils>=1.1.0'
+          'django-model-utils>=1.1.0,<=1.5.0'
       ],
       packages=['notifications',
                 'notifications.templatetags',


### PR DESCRIPTION
In django-model-utils >= 2.0, which introduces backwards incompatible changes, I'm getting _all_ notifications when calling `some_single_user.notifications.unread()`. I unfortunately don't have time to dig in and figure out what's wrong right now, but until someone is able to this should probably be merged in to prevent other people from getting confused.
