### PR TITLE
Add possibility to send level when adding new notification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,7 @@ To generate an notification anywhere in your code, simply import the notify sign
                 description=comment.comment, target=comment.content_object)
 
     notify.send(follow_instance.user, recipient=follow_instance.follow_object, verb=u'has followed you',
-                action_object=instance, description=u'', target=follow_instance.follow_object)
+                action_object=instance, description=u'', target=follow_instance.follow_object, level='success')
 
 Extra data
 ----------

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -150,7 +150,7 @@ class Notification(models.Model):
 
     """
     LEVELS = Choices('success', 'info', 'warning', 'error')
-    level = models.CharField(choices=LEVELS, default='info', max_length=20)
+    level = models.CharField(choices=LEVELS, default=LEVELS.info, max_length=20)
 
     recipient = models.ForeignKey(settings.AUTH_USER_MODEL, blank=False, related_name='notifications')
     unread = models.BooleanField(default=True, blank=False)
@@ -247,7 +247,8 @@ def notify_handler(verb, **kwargs):
         verb=text_type(verb),
         public=bool(kwargs.pop('public', True)),
         description=kwargs.pop('description', None),
-        timestamp=kwargs.pop('timestamp', now())
+        timestamp=kwargs.pop('timestamp', now()),
+        level=kwargs.pop('level', Notification.LEVELS.info),
     )
 
     for opt in ('target', 'action_object'):

--- a/notifications/signals.py
+++ b/notifications/signals.py
@@ -2,5 +2,5 @@ from django.dispatch import Signal
 
 notify = Signal(providing_args=[
     'recipient', 'actor', 'verb', 'action_object', 'target', 'description',
-    'timestamp'
+    'timestamp', 'level'
 ])


### PR DESCRIPTION
Just added a parameter to the signal in order to choose level.

notify.send(user, recipient=user, verb='...', level='success')