### PR TITLE
Fixes deprecation notice in Django 1.8

### DIFF
--- a/notifications/models.py
+++ b/notifications/models.py
@@ -1,7 +1,15 @@
 import datetime
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes import generic
+
+from django import get_version
+from distutils.version import StrictVersion
+
+if StrictVersion(get_version()) >= StrictVersion('1.8.0'):
+    from django.contrib.contenttypes.fields import GenericForeignKey
+else:
+    from django.contrib.contenttypes.generic import GenericForeignKey
+
 from django.db import models
 from django.core.exceptions import ImproperlyConfigured
 from six import text_type
@@ -157,7 +165,7 @@ class Notification(models.Model):
 
     actor_content_type = models.ForeignKey(ContentType, related_name='notify_actor')
     actor_object_id = models.CharField(max_length=255)
-    actor = generic.GenericForeignKey('actor_content_type', 'actor_object_id')
+    actor = GenericForeignKey('actor_content_type', 'actor_object_id')
 
     verb = models.CharField(max_length=255)
     description = models.TextField(blank=True, null=True)
@@ -165,14 +173,14 @@ class Notification(models.Model):
     target_content_type = models.ForeignKey(ContentType, related_name='notify_target',
         blank=True, null=True)
     target_object_id = models.CharField(max_length=255, blank=True, null=True)
-    target = generic.GenericForeignKey('target_content_type',
+    target = GenericForeignKey('target_content_type',
         'target_object_id')
 
     action_object_content_type = models.ForeignKey(ContentType,
         related_name='notify_action_object', blank=True, null=True)
     action_object_object_id = models.CharField(max_length=255, blank=True,
         null=True)
-    action_object = generic.GenericForeignKey('action_object_content_type',
+    action_object = GenericForeignKey('action_object_content_type',
         'action_object_object_id')
 
     timestamp = models.DateTimeField(default=now)


### PR DESCRIPTION
Fixes import path to get rid of the deprecation notice

```
notifications/models.py:4: RemovedInDjango19Warning: django.contrib.contenttypes.generic is deprecated and will be removed in Django 1.9. Its contents have been moved to the fields, forms, and admin submodules of django.contrib.contenttypes.
  from django.contrib.contenttypes import generic
```

Seen in Django 1.8