### PR TITLE
bugfix for wrong user unread notification count

### DIFF
--- a/notifications/templatetags/notifications_tags.py
+++ b/notifications/templatetags/notifications_tags.py
@@ -9,8 +9,10 @@ register = Library()
 def notifications_unread(context):
     if 'user' not in context:
         return ''
-    
-    user = context['user']
+
+    request = context['request']
+    user = request.user
     if user.is_anonymous():
         return ''
     return user.notifications.unread().count()
+


### PR DESCRIPTION
I noticed a problem in my website. when i change to users profile, my unread notifications count got changed, after i trace the problem i found in templatetags the current user change for every single profile page, so i change the code and my problem got solved