### PR TITLE
Added an app_label to Notifications model class

### DIFF
--- a/notifications/models.py
+++ b/notifications/models.py
@@ -194,6 +194,7 @@ class Notification(models.Model):
 
     class Meta:
         ordering = ('-timestamp', )
+        app_label = 'notifications'
 
     def __unicode__(self):
         ctx = {


### PR DESCRIPTION
The lack of app_label in the latest version was throwing a deprecation warning:
```
/notifications/models.py:131: RemovedInDjango19Warning: Model class notifications.models.Notification doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
```

This change fixes the warning.