### PR TITLE
Update model-utils version for compatibility issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,14 +19,14 @@ setup(name='django-notifications-hq',
 
       install_requires=[
           'django>=1.4',
-          'django-model-utils>=2.0.3',
+          'django-model-utils>=2.0.3,<2.4',
           'six>=1.9.0',
           'jsonfield>=1.0.3',
       ],
 
       test_requires=[
           'django>=1.4',
-          'django-model-utils>=2.0.3',
+          'django-model-utils>=2.0.3,<2.4',
           'six>=1.9.0',
           'jsonfield>=1.0.3',
           'pytz'


### PR DESCRIPTION
django-model-utils v2.4 removed PassThroughManager, which is used in the project