### PR TITLE
Include namespace with the urlpatterns

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Add the notifications urls to your urlconf::
 
     urlpatterns = patterns('',
         ...
-        url('^inbox/notifications/', include(notifications.urls)),
+        url('^inbox/notifications/', include(notifications.urls.urls)),
         ...
     )
 

--- a/notifications/urls.py
+++ b/notifications/urls.py
@@ -15,3 +15,5 @@ urlpatterns = [
     url(r'^api/unread_count/$', views.live_unread_notification_count, name='live_unread_notification_count'),
     url(r'^api/unread_list/$', views.live_unread_notification_list, name='live_unread_notification_list'),
 ]
+
+urls = (urlpatterns, 'notifications', 'notifications')


### PR DESCRIPTION
Otherwise update the doc to include the namespace (#103):
```
import notifications

urlpatterns = patterns('',
    ...
    url('^inbox/notifications/', include(notifications.urls, namespace='notifications')),
    ...
)
```