### PR TITLE
Tidy with flake8

### DIFF
--- a/notifications/tests/tests.py
+++ b/notifications/tests/tests.py
@@ -37,7 +37,8 @@ class NotificationTest(TestCase):
         delta = timezone.now().replace(tzinfo=utc) - localtime(notification.timestamp, pytz.timezone(settings.TIME_ZONE))
         self.assertTrue(delta.seconds < 60)
         # The delta between the two events will still be less than a second despite the different timezones
-        # The call to now and the immediate call afterwards will be within a short period of time, not 8 hours as the test above was originally.
+        # The call to now and the immediate call afterwards will be within a short period of time, not 8 hours as the
+        # test above was originally.
 
     @override_settings(USE_TZ=False)
     @override_settings(TIME_ZONE='Asia/Shanghai')
@@ -172,15 +173,21 @@ class NotificationTestPages(TestCase):
 
     def test_next_pages(self):
         self.login('to', 'pwd')
-        response = self.client.get(reverse('notifications:mark_all_as_read')+"?next="+reverse('notifications:unread'))
+        response = self.client.get(reverse('notifications:mark_all_as_read'), data={
+            "next": reverse('notifications:unread'),
+        })
         self.assertRedirects(response, reverse('notifications:unread'))
 
         slug = id2slug(self.to_user.notifications.first().id)
-        response = self.client.get(reverse('notifications:mark_as_read', args=[slug])+"?next="+reverse('notifications:unread'))
+        response = self.client.get(reverse('notifications:mark_as_read', args=[slug]), data={
+            "next": reverse('notifications:unread'),
+        })
         self.assertRedirects(response, reverse('notifications:unread'))
 
         slug = id2slug(self.to_user.notifications.first().id)
-        response = self.client.get(reverse('notifications:mark_as_unread', args=[slug])+"?next="+reverse('notifications:unread'))
+        response = self.client.get(reverse('notifications:mark_as_unread', args=[slug]), {
+            "next": reverse('notifications:unread'),
+        })
         self.assertRedirects(response, reverse('notifications:unread'))
 
     def test_delete_messages_pages(self):
@@ -247,14 +254,16 @@ class NotificationTestPages(TestCase):
         self.assertEqual(data['unread_count'], 10)
         self.assertEqual(len(data['unread_list']), 5)
 
-        response = self.client.get(reverse('notifications:live_unread_notification_list')+"?max=12")
+        response = self.client.get(reverse('notifications:live_unread_notification_list'), data={"max": "12"})
         data = json.loads(response.content.decode('utf-8'))
         self.assertEqual(sorted(list(data.keys())), ['unread_count', 'unread_list'])
         self.assertEqual(data['unread_count'], 10)
         self.assertEqual(len(data['unread_list']), 10)
 
         # Test with a bad 'max' value
-        response = self.client.get(reverse('notifications:live_unread_notification_list')+"?max=this_is_wrong")
+        response = self.client.get(reverse('notifications:live_unread_notification_list'), data={
+            "max": "this_is_wrong",
+        })
         data = json.loads(response.content.decode('utf-8'))
         self.assertEqual(sorted(list(data.keys())), ['unread_count', 'unread_list'])
         self.assertEqual(data['unread_count'], 10)
@@ -284,6 +293,6 @@ class NotificationTestPages(TestCase):
         request = self.factory.get('/notification/live_updater')
         request.user = self.to_user
 
-        page = render(request, 'notifications/test_tags.html', {'request': request})
+        render(request, 'notifications/test_tags.html', {'request': request})
 
-        #TODO: Add more tests to check what is being output.
+        # TODO: Add more tests to check what is being output.

--- a/notifications/tests/views.py
+++ b/notifications/tests/views.py
@@ -1,19 +1,18 @@
-from django.conf import settings
-from django.contrib.auth.decorators import login_required
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import render
 
 from notifications import notify
 import random
 
+
 def live_tester(request):
     notify.send(sender=request.user, recipient=request.user, verb='you loaded the page')
 
-    data = {
+    return render(request, 'test_live.html', {
         'unread_count': request.user.notifications.unread().count(),
         'notifications': request.user.notifications.all()
-    }
-    return render(request,'test_live.html',data)
-    
+    })
+
+
 def make_notification(request):
 
     the_notification = random.choice([
@@ -21,7 +20,7 @@ def make_notification(request):
         'cleaning the car',
         'jumping the shark',
         'testing the app',
-        ])
+    ])
 
-    notify.send(sender=request.user, recipient=request.user, verb='you asked for a notification - you are '+the_notification)
-
+    notify.send(sender=request.user, recipient=request.user,
+                verb='you asked for a notification - you are ' + the_notification)

--- a/notifications/urls.py
+++ b/notifications/urls.py
@@ -16,4 +16,3 @@ urlpatterns = [
     url(r'^api/unread_count/$', views.live_unread_notification_count, name='live_unread_notification_count'),
     url(r'^api/unread_list/$', views.live_unread_notification_list, name='live_unread_notification_list'),
 ]
-

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -131,8 +131,8 @@ def live_unread_notification_list(request):
     try:
         num_to_fetch = request.GET.get('max', 5)  # If they don't specify, make it 5.
         num_to_fetch = int(num_to_fetch)
-        num_to_fetch = max(1,num_to_fetch) # if num_to_fetch is negative, force at least one fetched notifications
-        num_to_fetch = min(num_to_fetch,100) # put a sane ceiling on the number retrievable
+        num_to_fetch = max(1, num_to_fetch)  # if num_to_fetch is negative, force at least one fetched notifications
+        num_to_fetch = min(num_to_fetch, 100)  # put a sane ceiling on the number retrievable
     except ValueError:
         num_to_fetch = 5  # If casting to an int fails, just make it 5.
 
@@ -148,7 +148,7 @@ def live_unread_notification_list(request):
             struct['action_object'] = str(n.action_object)
         unread_list.append(struct)
     data = {
-       'unread_count':request.user.notifications.unread().count(),
-       'unread_list':unread_list
+        'unread_count': request.user.notifications.unread().count(),
+        'unread_list': unread_list
     }
     return JsonResponse(data)


### PR DESCRIPTION
Also replace hard-coded querystring construction with using the `data` parameter of `Client.get()`