### PR TITLE
Bump version 1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+1.0
+-----
+
+The first major version that requires Django 1.7+.
+
+- Drop support for Django 1.6 and below (@zhang-z)
+- Django 1.9 compability (@illing2005)
+- Now depends on Django built-in migration facility, "south_migrations" dependence was removed (@zhang-z)
+- Make django-notification compatible with django-model-utils >= 2.4 ( #87, #88, #90 ) (@zhang-z)
+- Fix a RemovedInDjango110Warning in unittest (@zhang-z)
+- Fix pep8 & use setuptools (@areski)
+- Fix typo- in doc (@areski, @zhang-z)
+- Add app_name in urls.py (@zhang-z)
+- Use Django's vendored copy of six (@funkybob)
+- Tidy with flake8 (@funkybob)
+- Remove custom now() function (@funkybob, @yangyubo)
+- notify.send() accepts User or Group (@Evidlo)
+
 0.8.0
 -----
 
@@ -10,7 +28,7 @@ Changelog
 - Class-based classes (@alazaro)
 - Fixed urls in tests (@alazaro)
 - Added app_label to Notification model in order to fix a Django 1.9 deprecation warning (@Heldroe)
-- django-model-utils compatible issue (must >=2.0.3 and <2.4) (@zhangz)
+- django-model-utils compatible issue (must >=2.0.3 and <2.4) (@zhang-z)
 - Reliable setup.py versioning (@yangyubo)
 
 0.7.1

--- a/notifications/__init__.py
+++ b/notifications/__init__.py
@@ -8,6 +8,6 @@
 """
 
 # PEP 386-compliant version number: N.N[.N]+[{a|b|c|rc}N[.N]+][.postN][.devN]
-__version__ = '0.8.0'
+__version__ = '1.0'
 
 default_app_config = 'notifications.apps.Config'

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'django>=1.7',
         'django-model-utils>=2.0.3',
         'jsonfield>=1.0.3',
+        'pytz'
     ],
     test_requires=[
         'django>=1.7',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
     test_requires=[
         'django>=1.7',
         'django-model-utils>=2.0.3',
-        'six>=1.9.0',
         'jsonfield>=1.0.3',
         'pytz'
     ],


### PR DESCRIPTION
The first major version that requires Django 1.7+.

## Changelog

- Drop support for Django 1.6 and below (@zhang-z)
- Django 1.9 compability (@illing2005)
- Now depends on Django built-in migration facility, "south_migrations" dependence was removed (@zhang-z)
- Make django-notification compatible with django-model-utils >= 2.4 ( #87, #88, #90 ) (@zhang-z)
- Fix a RemovedInDjango110Warning in unittest (@zhang-z)
- Fix pep8 & use setuptools (@areski)
- Fix typo- in doc (@areski, @zhang-z)
- Add app_name in urls.py (@zhang-z)
- Use Django's vendored copy of six (@funkybob)
- Tidy with flake8 (@funkybob)
- Remove custom now() function (@funkybob, @yangyubo)
- notify.send() accepts User or Group (@Evidlo)