### PR TITLE
Fixed parameter name error in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -267,7 +267,7 @@ How to use:
      1. ``badge_id`` (default ``live_notify_badge``) - The `id` attribute of the element to show the unread count, that will be periodically updated.
      #. ``menu_id`` (default ``live_notify_list``) - The `id` attribute of the element to insert a list of unread items, that will be periodically updated.
      #. ``refresh_period`` (default ``15``) - How often to fetch unread items from the server (integer in seconds).
-     #. ``to_fetch`` (default ``5``) - How many notifications to fetch each time.
+     #. ``fetch`` (default ``5``) - How many notifications to fetch each time.
      #. ``callbacks`` (default ``<empty string>``) - A comma-separated list of javascript functions to call each period.
      #. ``api_url_name`` (default ``list``) - The name of the API to call (this can be either ``list`` or ``count``).
 


### PR DESCRIPTION
There is no to_fetch parameter. The correct name is fetch.