### PR TITLE
Redirect to unread view after mark notification as read

### DIFF
--- a/notifications/tests/tests.py
+++ b/notifications/tests/tests.py
@@ -177,7 +177,7 @@ class NotificationTestPages(TestCase):
         self.assertTrue(len(response.context['notifications']) < self.message_count)
 
         response = self.client.get(reverse('notifications:mark_all_as_read'))
-        self.assertRedirects(response, reverse('notifications:all'))
+        self.assertRedirects(response, reverse('notifications:unread'))
         response = self.client.get(reverse('notifications:unread'))
         self.assertEqual(len(response.context['notifications']), len(self.to_user.notifications.unread()))
         self.assertEqual(len(response.context['notifications']), 0)

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -63,7 +63,7 @@ def mark_all_as_read(request):
 
     if _next:
         return redirect(_next)
-    return redirect('notifications:all')
+    return redirect('notifications:unread')
 
 
 @login_required
@@ -79,7 +79,7 @@ def mark_as_read(request, slug=None):
     if _next:
         return redirect(_next)
 
-    return redirect('notifications:all')
+    return redirect('notifications:unread')
 
 
 @login_required
@@ -95,7 +95,7 @@ def mark_as_unread(request, slug=None):
     if _next:
         return redirect(_next)
 
-    return redirect('notifications:all')
+    return redirect('notifications:unread')
 
 
 @login_required


### PR DESCRIPTION
In its current form it does not make sense. 

You press on the cross (the message is marked as read), but after redirected to the all notification view and still see marked message. It's very simple to fix.