### PR TITLE
Allow recipient paramter to be a list of users

### DIFF
--- a/notifications/models.py
+++ b/notifications/models.py
@@ -251,6 +251,8 @@ def notify_handler(verb, **kwargs):
     # Check if User or Group
     if isinstance(recipient, Group):
         recipients = recipient.user_set.all()
+    elif type(recipient) is list:
+        recipients = recipient
     else:
         recipients = [recipient]
 

--- a/notifications/tests/tests.py
+++ b/notifications/tests/tests.py
@@ -63,7 +63,11 @@ class NotificationManagersTest(TestCase):
             notify.send(self.from_user, recipient=self.to_user, verb='commented', action_object=self.from_user)
         # Send notification to group
         notify.send(self.from_user, recipient=self.to_group, verb='commented', action_object=self.from_user)
-        self.message_count += 1
+        
+        # Send notification to all users
+        notify.send(self.from_user, recipient=User.objects.all(), verb='commented', action_object=self.from_user)
+        
+        self.message_count += 2
 
     def test_unread_manager(self):
         self.assertEqual(Notification.objects.unread().count(), self.message_count)


### PR DESCRIPTION
This will allow us to do something like:

```
notify.send(user, verb='was added', recipient=User.objects.all())
```