### PR TITLE
Django 1.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,7 @@ matrix:
       env: DJANGO=1.7
     - python: "3.3"
       env: DJANGO=1.9
+    - python: "3.3"
+      env: DJANGO=1.10
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - DJANGO=1.7
   - DJANGO=1.8
   - DJANGO=1.9
+  - DJANGO=1.10
 install:
 # command to install dependencies
   - "pip install coveralls"

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Requirements
 ============
 
 - Python 2.7, 3.3, 3.4, 3.5
-- Django 1.7, 1.8, 1.9
+- Django 1.7, 1.8, 1.9, 1.10
 
 Installation
 ============

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,11 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
+	'Framework :: Django',
+	'Framework :: Django :: 1.10',
+	'Framework :: Django :: 1.9',
+	'Framework :: Django :: 1.8',
+	'Framework :: Django :: 1.7',
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python',


### PR DESCRIPTION
About 1 month ago Django 1.10 was released. It's latest long-term support release (will get security and data loss fixes for three years period). I'm runned existing tests successfully.

Also, is good time to drop support some old django version.