### PR TITLE
 Mark notifications as read for API requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -254,10 +254,10 @@ There are two possible API calls that can be made:
 
    Query string arguments:
 
-   - **max**
-   - **mark_as_read**
+   - **max** - maximum length of unread list.
+   - **mark_as_read** - mark notification in list as read.
 
-   For example, get ``api/unread_list/?max=3&mark_as_read=true`` returns 3 notifications and mark them read (remove from list on next time).
+   For example, get ``api/unread_list/?max=3&mark_as_read=true`` returns 3 notifications and mark them read (remove from list on next request).
 
 
 How to use:

--- a/README.rst
+++ b/README.rst
@@ -239,18 +239,25 @@ for updating specific fields within a django template.
 
 There are two possible API calls that can be made:
 
- 1. ``api/unread_count/`` that returns a javascript object with 1 key: ``unread_count`` eg::
+1. ``api/unread_count/`` that returns a javascript object with 1 key: ``unread_count`` eg::
 
         {"unread_count":1}
 
- #. ``api/unread_list/`` that returns a javascript object with 2 keys: `unread_count` and `unread_list` eg::
+#. ``api/unread_list/`` that returns a javascript object with 2 keys: `unread_count` and `unread_list` eg::
 
-         {
-          "unread_count":1,
-          "unread_list":[--list of json representations of notifications--]
-         }
+        {
+         "unread_count":1,
+         "unread_list":[--list of json representations of notifications--]
+        }
 
-     Representations of notifications are based on the django method: ``model_to_dict``
+   Representations of notifications are based on the django method: ``model_to_dict``
+
+   Query string arguments:
+
+   - **max**
+   - **mark_as_read**
+
+   For example, get ``api/unread_list/?max=3&mark_as_read=true`` returns 3 notifications and mark them read (remove from list on next time).
 
 
 How to use:

--- a/notifications/tests/tests.py
+++ b/notifications/tests/tests.py
@@ -298,19 +298,21 @@ class NotificationTestPages(TestCase):
     def test_unread_list_api_mark_as_read(self):
         self.login('to', 'pwd')
         num_requested = 3
-        response = self.client.get(reverse('notifications:live_unread_notification_list'), data={
-            "max": num_requested,
-            "mark_as_read": 1,
-        })
+        response = self.client.get(
+            reverse('notifications:live_unread_notification_list'),
+            data={"max": num_requested, "mark_as_read": 1}
+        )
         data = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(data['unread_count'], self.message_count - num_requested)
+        self.assertEqual(data['unread_count'],
+                         self.message_count - num_requested)
         self.assertEqual(len(data['unread_list']), num_requested)
-        response = self.client.get(reverse('notifications:live_unread_notification_list'), data={
-            "max": num_requested,
-            "mark_as_read": 1,
-        })
+        response = self.client.get(
+            reverse('notifications:live_unread_notification_list'),
+            data={"max": num_requested, "mark_as_read": 1}
+        )
         data = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(data['unread_count'], 4)
+        self.assertEqual(data['unread_count'],
+                         self.message_count - 2*num_requested)
         self.assertEqual(len(data['unread_list']), num_requested)
 
     def test_live_update_tags(self):

--- a/notifications/tests/tests.py
+++ b/notifications/tests/tests.py
@@ -295,6 +295,24 @@ class NotificationTestPages(TestCase):
         self.assertEqual(len(data['unread_list']), 1)
         self.assertEqual(data['unread_list'][0]['verb'], 'commented')
 
+    def test_unread_list_api_mark_as_read(self):
+        self.login('to', 'pwd')
+        num_requested = 3
+        response = self.client.get(reverse('notifications:live_unread_notification_list'), data={
+            "max": num_requested,
+            "mark_as_read": 1,
+        })
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(data['unread_count'], self.message_count - num_requested)
+        self.assertEqual(len(data['unread_list']), num_requested)
+        response = self.client.get(reverse('notifications:live_unread_notification_list'), data={
+            "max": num_requested,
+            "mark_as_read": 1,
+        })
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(data['unread_count'], 4)
+        self.assertEqual(len(data['unread_list']), num_requested)
+
     def test_live_update_tags(self):
         from django.shortcuts import render
 

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -156,6 +156,8 @@ def live_unread_notification_list(request):
         if n.action_object:
             struct['action_object'] = str(n.action_object)
         unread_list.append(struct)
+        if request.GET.get('mark_as_read'):
+            n.mark_as_read()
     data = {
         'unread_count': request.user.notifications.unread().count(),
         'unread_list': unread_list


### PR DESCRIPTION
This pull request adds new functionality to API with query string argument ``mark_as_read``.

Set ``mark_as_read`` to any not null value delete this notifications on the next request.

For example, I use this django app for messages but returns them to user through browser's Notifications API. So I'm need remove notification from unread_list or can't show all user's notification correctly.

A little bit of documentation and tests included.