### PR TITLE
Fixes bug in notifications templatetags module

### DIFF
--- a/notifications/templates/notifications/list.html
+++ b/notifications/templates/notifications/list.html
@@ -3,3 +3,11 @@
     {% include 'notifications/notice.html' %}
   {% endfor %}
 </ul>
+
+{% for num in notifications.paginator.page_range %}
+  {% ifequal num notifications.number %}
+    <span class="current"><b>{{ num }}</b></span>
+  {% else %}
+    <a href="?page={{ num }}"> {{ num }}</a>
+  {% endifequal %}
+{% endfor %}

--- a/notifications/templatetags/notifications_tags.py
+++ b/notifications/templatetags/notifications_tags.py
@@ -79,9 +79,9 @@ def user_context(context):
 
     request = context['request']
     try:
-	    user = request.user
-    	return user
-	except Exception as e:
-		pass 
-		   	
+        user = request.user
+        return user
+    except Exception as e:
+        pass
+
     return None

--- a/notifications/templatetags/notifications_tags.py
+++ b/notifications/templatetags/notifications_tags.py
@@ -78,7 +78,10 @@ def user_context(context):
         return None
 
     request = context['request']
-    user = request.user
-    if user.is_anonymous():
-        return None
-    return user
+    try:
+	    user = request.user
+    	return user
+	except Exception as e:
+		pass 
+		   	
+    return None

--- a/notifications/urls.py
+++ b/notifications/urls.py
@@ -7,7 +7,7 @@ from . import views
 
 app_name = 'notifications'
 urlpatterns = [
-    url(r'^$', views.view_all_notifications_paged, name='all'),
+    url(r'^$', views.view_all_unread_notifications_paged, name='all'),
     url(r'^unread/$', views.UnreadNotificationsList.as_view(), name='unread'),
     url(r'^mark-all-as-read/$', views.mark_all_as_read, name='mark_all_as_read'),
     url(r'^mark-as-read/(?P<slug>\d+)/$', views.mark_as_read, name='mark_as_read'),

--- a/notifications/urls.py
+++ b/notifications/urls.py
@@ -7,7 +7,7 @@ from . import views
 
 app_name = 'notifications'
 urlpatterns = [
-    url(r'^$', views.AllNotificationsList.as_view(), name='all'),
+    url(r'^$', views.view_all_notifications_paged, name='all'),
     url(r'^unread/$', views.UnreadNotificationsList.as_view(), name='unread'),
     url(r'^mark-all-as-read/$', views.mark_all_as_read, name='mark_all_as_read'),
     url(r'^mark-as-read/(?P<slug>\d+)/$', views.mark_as_read, name='mark_as_read'),

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -62,7 +62,10 @@ class UnreadNotificationsList(NotificationViewList):
 @login_required()
 def view_all_notifications_paged(request):
 
-    qs = request.user.notifications.all()
+    if getattr(settings, 'NOTIFICATIONS_SOFT_DELETE', False):
+        qs = request.user.notifications.active()
+    else:
+        qs = request.user.notifications.all()
 
     paginator = Paginator(qs, getattr(settings, 'NOTIFICATIONS_PAGE_LEN', 25))
     page = request.GET.get('page', 1)

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -60,12 +60,9 @@ class UnreadNotificationsList(NotificationViewList):
 
 
 @login_required()
-def view_all_notifications_paged(request):
+def view_all_unread_notifications_paged(request):
 
-    if getattr(settings, 'NOTIFICATIONS_SOFT_DELETE', False):
-        qs = request.user.notifications.active()
-    else:
-        qs = request.user.notifications.all()
+    qs = request.user.notifications.unread()
 
     paginator = Paginator(qs, getattr(settings, 'NOTIFICATIONS_PAGE_LEN', 25))
     page = request.GET.get('page', 1)


### PR DESCRIPTION
when filtering traffic based on user agent, sometimes a request is processed without a user at all, so the line `request.user` on line 81 of `templatetags/notifications_tags.py` fails when trying to render a 403 template that uses the `{%load notifications_tags %}` template tag.

This fixes that issue.