### PR TITLE
[fix](notification) use model field JSONField from django.contrib

### DIFF
--- a/notifications/migrations/0003_notification_data.py
+++ b/notifications/migrations/0003_notification_data.py
@@ -2,7 +2,12 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import jsonfield.fields
+from django import get_version
+from distutils.version import StrictVersion
+if StrictVersion(get_version()) >= StrictVersion('1.9.0'):
+    from django.contrib.postgres.fields import JSONField
+else:
+    from jsonfield.fields import JSONField
 
 
 class Migration(migrations.Migration):
@@ -15,7 +20,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='notification',
             name='data',
-            field=jsonfield.fields.JSONField(null=True, blank=True),
+            field=JSONField(null=True, blank=True),
             preserve_default=True,
         ),
     ]

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -18,7 +18,8 @@ from .utils import id2slug
 from .signals import notify
 
 from model_utils import Choices
-if StrictVersion(get_version()) >= StrictVersion('1.9.0'):
+
+if settings.DATABASES['default']['ENGINE'] == 'django.db.backends.postgresql_psycopg2' and StrictVersion(get_version()) >= StrictVersion('1.9.0'):
     from django.contrib.postgres.fields import JSONField
 else:
     from jsonfield.fields import JSONField

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -18,7 +18,10 @@ from .utils import id2slug
 from .signals import notify
 
 from model_utils import Choices
-from jsonfield.fields import JSONField
+if StrictVersion(get_version()) >= StrictVersion('1.9.0'):
+    from django.contrib.postgres.fields import JSONField
+else:
+    from jsonfield.fields import JSONField
 
 from django.contrib.auth.models import Group
 
@@ -222,6 +225,7 @@ class Notification(models.Model):
         if not self.unread:
             self.unread = True
             self.save()
+
 
 # 'NOTIFY_USE_JSONFIELD' is for backward compatibility
 # As app name is 'notifications', let's use 'NOTIFICATIONS' consistently from now

--- a/setup.py
+++ b/setup.py
@@ -48,11 +48,11 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-	'Framework :: Django',
-	'Framework :: Django :: 1.10',
-	'Framework :: Django :: 1.9',
-	'Framework :: Django :: 1.8',
-	'Framework :: Django :: 1.7',
+        'Framework :: Django',
+        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.7',
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python',


### PR DESCRIPTION
Using django-jsonfield doesn't work as it still use SubfieldBase which has been deprecated and removed in in Django 1.10.
This patch fallback on new JSONField from django.contrib when django version is >= 1.9.