### PR TITLE
update queryset methods mark_as_sent() and mark_as_unsent()

### DIFF
--- a/notifications/models.py
+++ b/notifications/models.py
@@ -125,11 +125,13 @@ class NotificationQuerySet(models.query.QuerySet):
         return qs.update(deleted=False)
 
     def mark_as_unsent(self, recipient=None):
+        qs = self.sent()
         if recipient:
             qs = self.filter(recipient=recipient)
         return qs.update(emailed=False)
 
     def mark_as_sent(self, recipient=None):
+        qs = self.unsent()
         if recipient:
             qs = self.filter(recipient=recipient)
         return qs.update(emailed=True)


### PR DESCRIPTION
it will raise error **local variable 'qs' referenced before assignment**, if recipient is not provided when using the query method **mark_as_sent** and **mark_as_unsent**.