### PR TITLE
setup.py: added fix for not a directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 import re
 import ast
-from setuptools import setup
+from distutils.core import setup
 
 
 _version_re = re.compile(r'__version__\s+=\s+(.*)')


### PR DESCRIPTION
Imported setup from distutils.core to fix the not a directory error