### PR TITLE
Remove duplicate url patterns by a more pythonic alternative

### DIFF
--- a/notifications/urls.py
+++ b/notifications/urls.py
@@ -7,32 +7,22 @@ from django import get_version
 from . import views
 
 if StrictVersion(get_version()) >= StrictVersion('2.0'):
-    from django.urls import path
-    urlpatterns = [
-        path('', views.AllNotificationsList.as_view(), name='all'),
-        path('unread/', views.UnreadNotificationsList.as_view(), name='unread'),
-        path('mark-all-as-read/', views.mark_all_as_read, name='mark_all_as_read'),
-        path('mark-as-read/<slug:slug>/', views.mark_as_read, name='mark_as_read'),
-        path('mark-as-unread/<slug:slug>/', views.mark_as_unread, name='mark_as_unread'),
-        path('delete/<slug:slug>/', views.delete, name='delete'),
-        path('api/unread_count/', views.live_unread_notification_count, name='live_unread_notification_count'),
-        path('api/all_count/', views.live_all_notification_count, name='live_all_notification_count'),
-        path('api/unread_list/', views.live_unread_notification_list, name='live_unread_notification_list'),
-        path('api/all_list/', views.live_all_notification_list, name='live_all_notification_list'),
-    ]
+    from django.urls import path as pattern
 else:
-    from django.conf.urls import url
-    urlpatterns = [
-        url(r'^$', views.AllNotificationsList.as_view(), name='all'),
-        url(r'^unread/$', views.UnreadNotificationsList.as_view(), name='unread'),
-        url(r'^mark-all-as-read/$', views.mark_all_as_read, name='mark_all_as_read'),
-        url(r'^mark-as-read/(?P<slug>\d+)/$', views.mark_as_read, name='mark_as_read'),
-        url(r'^mark-as-unread/(?P<slug>\d+)/$', views.mark_as_unread, name='mark_as_unread'),
-        url(r'^delete/(?P<slug>\d+)/$', views.delete, name='delete'),
-        url(r'^api/unread_count/$', views.live_unread_notification_count, name='live_unread_notification_count'),
-        url(r'^api/all_count/$', views.live_all_notification_count, name='live_all_notification_count'),
-        url(r'^api/unread_list/$', views.live_unread_notification_list, name='live_unread_notification_list'),
-        url(r'^api/all_list/', views.live_all_notification_list, name='live_all_notification_list'),
-    ]
+    from django.conf.urls import url as pattern
+
+
+urlpatterns = [
+    pattern('', views.AllNotificationsList.as_view(), name='all'),
+    pattern('unread/', views.UnreadNotificationsList.as_view(), name='unread'),
+    pattern('mark-all-as-read/', views.mark_all_as_read, name='mark_all_as_read'),
+    pattern('mark-as-read/<slug:slug>/', views.mark_as_read, name='mark_as_read'),
+    pattern('mark-as-unread/<slug:slug>/', views.mark_as_unread, name='mark_as_unread'),
+    pattern('delete/<slug:slug>/', views.delete, name='delete'),
+    pattern('api/unread_count/', views.live_unread_notification_count, name='live_unread_notification_count'),
+    pattern('api/all_count/', views.live_all_notification_count, name='live_all_notification_count'),
+    pattern('api/unread_list/', views.live_unread_notification_list, name='live_unread_notification_list'),
+    pattern('api/all_list/', views.live_all_notification_list, name='live_all_notification_list'),
+]
 
 app_name = 'notifications'


### PR DESCRIPTION
Hi guys, I remove a lot of unnecessary code in the urls.py, who makes the fallback for the old Django versions below the 2.0.

The solution I think, it's more pythonic in my opinion. What you guys think?