### PR TITLE
Add support to register_notify_callbacks for marking notifications as read

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ There are two possible API calls that can be made:
         of javascript functions to call each period.
     6.  `api_name` (default `list`) - The name of the API to call (this
         can be either `list` or `count`).
+    7. ``mark_as_read`` (default ``False``) - Marks notifications as read when fetched.
 
 3.  To insert a live-updating unread count, use the following template:
 

--- a/notifications/static/notifications/notify.js
+++ b/notifications/static/notifications/notify.js
@@ -5,13 +5,15 @@ var notify_fetch_count;
 var notify_unread_url;
 var notify_mark_all_unread_url;
 var notify_refresh_period = 15000;
+// Set notify_mark_as_read to true to mark notifications as read when fetched
+var notify_mark_as_read = false;
 var consecutive_misfires = 0;
 var registered_functions = [];
 
 function fill_notification_badge(data) {
     var badges = document.getElementsByClassName(notify_badge_class);
     if (badges) {
-        for(var i = 0; i < badges.length; i++){
+        for(var i = 0; i < badges.length; i++) {
             badges[i].innerHTML = data.unread_count;
         }
     }
@@ -22,22 +24,23 @@ function fill_notification_list(data) {
     if (menus) {
         var messages = data.unread_list.map(function (item) {
             var message = "";
-            if(typeof item.actor !== 'undefined'){
+
+            if (typeof item.actor !== 'undefined') {
                 message = item.actor;
             }
-            if(typeof item.verb !== 'undefined'){
+            if (typeof item.verb !== 'undefined') {
                 message = message + " " + item.verb;
             }
-            if(typeof item.target !== 'undefined'){
+            if (typeof item.target !== 'undefined') {
                 message = message + " " + item.target;
             }
-            if(typeof item.timestamp !== 'undefined'){
+            if (typeof item.timestamp !== 'undefined') {
                 message = message + " " + item.timestamp;
             }
             return '<li>' + message + '</li>';
         }).join('')
 
-        for (var i = 0; i < menus.length; i++){
+        for (var i = 0; i < menus.length; i++) {
             menus[i].innerHTML = messages;
         }
     }
@@ -48,31 +51,37 @@ function register_notifier(func) {
 }
 
 function fetch_api_data() {
+    // only fetch data if a function is setup
     if (registered_functions.length > 0) {
-        //only fetch data if a function is setup
         var r = new XMLHttpRequest();
-        r.addEventListener('readystatechange', function(event){
-            if (this.readyState === 4){
-                if (this.status === 200){
+        var params = '?max=' + notify_fetch_count;
+
+        if (notify_mark_as_read) {
+            params += '&mark_as_read=true';
+        }
+
+        r.addEventListener('readystatechange', function(event) {
+            if (this.readyState === 4) {
+                if (this.status === 200) {
                     consecutive_misfires = 0;
                     var data = JSON.parse(r.responseText);
-                    for(var i = 0; i < registered_functions.length; i++) {
+                    for (var i = 0; i < registered_functions.length; i++) {
                        registered_functions[i](data);
                     }
-                }else{
+                } else {
                     consecutive_misfires++;
                 }
             }
-        })
-        r.open("GET", notify_api_url+'?max='+notify_fetch_count, true);
+        });
+        r.open("GET", notify_api_url + params, true);
         r.send();
     }
     if (consecutive_misfires < 10) {
-        setTimeout(fetch_api_data,notify_refresh_period);
+        setTimeout(fetch_api_data, notify_refresh_period);
     } else {
         var badges = document.getElementsByClassName(notify_badge_class);
         if (badges) {
-            for (var i = 0; i < badges.length; i++){
+            for (var i = 0; i < badges.length; i++) {
                 badges[i].innerHTML = "!";
                 badges[i].title = "Connection lost!"
             }

--- a/notifications/static/notifications/notify.js
+++ b/notifications/static/notifications/notify.js
@@ -13,7 +13,7 @@ var registered_functions = [];
 function fill_notification_badge(data) {
     var badges = document.getElementsByClassName(notify_badge_class);
     if (badges) {
-        for(var i = 0; i < badges.length; i++) {
+        for (var i = 0; i < badges.length; i++) {
             badges[i].innerHTML = data.unread_count;
         }
     }

--- a/notifications/templatetags/notifications_tags.py
+++ b/notifications/templatetags/notifications_tags.py
@@ -43,7 +43,8 @@ def register_notify_callbacks(badge_class='live_notify_badge',  # pylint: disabl
                               api_name='list',
                               fetch=5,
                               nonce=None,
-                              mark_as_read=False):
+                              mark_as_read=False
+                              ):
     refresh_period = int(refresh_period) * 1000
 
     if api_name == 'list':

--- a/notifications/templatetags/notifications_tags.py
+++ b/notifications/templatetags/notifications_tags.py
@@ -42,8 +42,8 @@ def register_notify_callbacks(badge_class='live_notify_badge',  # pylint: disabl
                               callbacks='',
                               api_name='list',
                               fetch=5,
-                              nonce=None
-                              ):
+                              nonce=None,
+                              mark_as_read=False):
     refresh_period = int(refresh_period) * 1000
 
     if api_name == 'list':
@@ -60,6 +60,7 @@ def register_notify_callbacks(badge_class='live_notify_badge',  # pylint: disabl
         notify_unread_url='{unread_url}';
         notify_mark_all_unread_url='{mark_all_unread_url}';
         notify_refresh_period={refresh};
+        notify_mark_as_read={mark_as_read};
     """.format(
         badge_class=badge_class,
         menu_class=menu_class,
@@ -67,7 +68,8 @@ def register_notify_callbacks(badge_class='live_notify_badge',  # pylint: disabl
         api_url=api_url,
         unread_url=reverse('notifications:unread'),
         mark_all_unread_url=reverse('notifications:mark_all_as_read'),
-        fetch_count=fetch
+        fetch_count=fetch,
+        mark_as_read=mark_as_read
     )
 
     # add a nonce value to the script tag if one is provided


### PR DESCRIPTION
This adds a new parameter `mark_as_read` to `register_notify_callbacks` to mark notifications as read when fetched.

I also did some minor style cleanup to the JS.