### PR TITLE
Settings rework

### DIFF
--- a/notifications/models.py
+++ b/notifications/models.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 from django.utils.six import text_type
 from jsonfield.fields import JSONField
 from model_utils import Choices
-from notifications import settings as notifications_settings
+from notifications.settings import notifications_settings
 from notifications.signals import notify
 from notifications.utils import id2slug
 
@@ -24,11 +24,8 @@ else:
     from django.contrib.contenttypes.generic import GenericForeignKey  # noqa
 
 
-EXTRA_DATA = notifications_settings.get_config()['USE_JSONFIELD']
-
-
 def is_soft_delete():
-    return notifications_settings.get_config()['SOFT_DELETE']
+    return notifications_settings.SOFT_DELETE
 
 
 def assert_soft_delete():
@@ -299,7 +296,7 @@ def notify_handler(verb, **kwargs):
                 setattr(newnotify, '%s_content_type' % opt,
                         ContentType.objects.get_for_model(obj))
 
-        if kwargs and EXTRA_DATA:
+        if kwargs and notifications_settings.USE_JSONFIELD:
             newnotify.data = kwargs
 
         newnotify.save()

--- a/notifications/settings.py
+++ b/notifications/settings.py
@@ -1,6 +1,7 @@
 ''' Django notifications settings file '''
 # -*- coding: utf-8 -*-
 from django.conf import settings
+from django.utils.functional import cached_property
 
 
 CONFIG_DEFAULTS = {
@@ -11,10 +12,27 @@ CONFIG_DEFAULTS = {
 }
 
 
-def get_config():
-    user_config = getattr(settings, 'DJANGO_NOTIFICATIONS_CONFIG', {})
+class NotificationSettings(object):
 
-    config = CONFIG_DEFAULTS.copy()
-    config.update(user_config)
+    def _get_config(self, config_name):
+        _settings = getattr(settings, 'DJANGO_NOTIFICATIONS_CONFIG', {})
+        return _settings.get(config_name, CONFIG_DEFAULTS[config_name])
 
-    return config
+    @property
+    def USE_JSONFIELD(self):
+        return self._get_config('USE_JSONFIELD')
+
+    @property
+    def PAGINATE_BY(self):
+        return self._get_config('PAGINATE_BY')
+
+    @property
+    def SOFT_DELETE(self):
+        return self._get_config('SOFT_DELETE')
+
+    @property
+    def NUM_TO_FETCH(self):
+        return self._get_config('NUM_TO_FETCH')
+
+
+notifications_settings = NotificationSettings()

--- a/notifications/settings.py
+++ b/notifications/settings.py
@@ -1,7 +1,6 @@
 ''' Django notifications settings file '''
 # -*- coding: utf-8 -*-
 from django.conf import settings
-from django.utils.functional import cached_property
 
 
 CONFIG_DEFAULTS = {

--- a/notifications/tests/urls.py
+++ b/notifications/tests/urls.py
@@ -4,20 +4,21 @@ from distutils.version import StrictVersion  # pylint: disable=no-name-in-module
 
 from django import get_version
 from django.contrib import admin
-from django.contrib.auth.views import login
 from notifications.tests.views import (live_tester,  # pylint: disable=no-name-in-module,import-error
                                        make_notification)
 
 if StrictVersion(get_version()) >= StrictVersion('2.0'):
+    from django.contrib.auth.views import LoginView
     from django.urls import include, path  # noqa
     urlpatterns = [
         path('test_make/', make_notification),
         path('test/', live_tester),
-        path('login/', login, name='login'),  # reverse for django login is not working
+        path('login/', LoginView.as_view(), name='login'),  # reverse for django login is not working
         path('admin/', admin.site.urls),
         path('', include('notifications.urls', namespace='notifications')),
     ]
 else:
+    from django.contrib.auth.views import login
     from django.conf.urls import include, url
     urlpatterns = [
         url(r'^login/$', login, name='login'),  # reverse for django login is not working

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -8,10 +8,9 @@ from django.forms import model_to_dict
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
 from django.views.generic import ListView
-from notifications import settings
+from notifications.settings import notifications_settings
 from notifications.models import Notification
 from notifications.utils import id2slug, slug2id
-from notifications.settings import get_config
 
 if StrictVersion(get_version()) >= StrictVersion('1.7.0'):
     from django.http import JsonResponse  # noqa
@@ -32,7 +31,7 @@ else:
 class NotificationViewList(ListView):
     template_name = 'notifications/list.html'
     context_object_name = 'notifications'
-    paginate_by = settings.get_config()['PAGINATE_BY']
+    paginate_by = notifications_settings.PAGINATE_BY
 
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):
@@ -46,7 +45,7 @@ class AllNotificationsList(NotificationViewList):
     """
 
     def get_queryset(self):
-        if settings.get_config()['SOFT_DELETE']:
+        if notifications_settings.SOFT_DELETE:
             qset = self.request.user.notifications.active()
         else:
             qset = self.request.user.notifications.all()
@@ -109,7 +108,7 @@ def delete(request, slug=None):
     notification = get_object_or_404(
         Notification, recipient=request.user, id=notification_id)
 
-    if settings.get_config()['SOFT_DELETE']:
+    if notifications_settings.SOFT_DELETE:
         notification.deleted = True
         notification.save()
     else:
@@ -154,7 +153,7 @@ def live_unread_notification_list(request):
         }
         return JsonResponse(data)
 
-    default_num_to_fetch = get_config()['NUM_TO_FETCH']
+    default_num_to_fetch = notifications_settings.NUM_TO_FETCH
     try:
         # If they don't specify, make it 5.
         num_to_fetch = request.GET.get('max', default_num_to_fetch)
@@ -201,7 +200,7 @@ def live_all_notification_list(request):
         }
         return JsonResponse(data)
 
-    default_num_to_fetch = get_config()['NUM_TO_FETCH']
+    default_num_to_fetch = notifications_settings.NUM_TO_FETCH
     try:
         # If they don't specify, make it 5.
         num_to_fetch = request.GET.get('max', default_num_to_fetch)


### PR DESCRIPTION
Improve readability and performace for settings.

Instead of reading cloning the whole `settings` object each time a config is requested we use a proxy-class which has each config as a `property` getter.

