### PR TITLE
Add tests for Python 3.7 and latest versions of Django.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: focal
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,17 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 env:
   - DJANGO=1.7
   - DJANGO=1.8
   - DJANGO=1.9
   - DJANGO=1.10
   - DJANGO=1.11
+  - DJANGO=1.11.17
   - DJANGO=2.0
+  - DJANGO=2.1
+  - DJANGO=2.2
 install:
 # command to install dependencies
   - "pip install coveralls"
@@ -24,11 +28,27 @@ matrix:
   exclude:
     - python: "2.7"
       env: DJANGO=2.0
+    - python: "2.7"
+      env: DJANGO=2.1
+    - python: "2.7"
+      env: DJANGO=2.2
+    - python: "3.4"
+      env: DJANGO=2.1
+    - python: "3.4"
+      env: DJANGO=2.2
     - python: "3.5"
       env: DJANGO=1.7
     - python: "3.6"
       env: DJANGO=1.7
-
-
+    - python: "3.7"
+      env: DJANGO=1.7
+    - python: "3.7"
+      env: DJANGO=1.8
+    - python: "3.7"
+      env: DJANGO=1.9
+    - python: "3.7"
+      env: DJANGO=1.10
+    - python: "3.7"
+      env: DJANGO=1.11
 after_success:
   - coveralls

--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@ Nomenclature of this specification is based on the Activity Streams Spec: `<http
 Requirements
 ============
 
-- Python 2.7, 3.4, 3.5, 3.6
-- Django 1.7, 1.8, 1.9, 1.10, 1.11, 2.0
+- Python 2.7, 3.4, 3.5, 3.6, 3.7
+- Django 1.7, 1.8, 1.9, 1.10, 1.11, 2.0, 2.1, 2.2
 
 Installation
 ============

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,10 @@
 envlist =
     py{27,33,34}-django17
     py{27,33,34,35,36}-django{18,19,110,111}
-    py{34,35,36}-django200
+    py{37}-django{111}
+    py{34,35,36,37}-django200
+    py{35,36,37}-django210
+    py{35,36,37}-django220
 
 [testenv]
 commands =
@@ -15,4 +18,6 @@ deps =
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
-    django200: Django>=2.0,<3.0
+    django200: Django>=2.0,<2.1
+    django210: Django>=2.1,<2.2
+    django220: Django>=2.2,<3.0


### PR DESCRIPTION
Thanks for maintaining this repo! I noticed the docs only specify Django/Python compatibility up to Python 3.6 and Django 2.0.

Tests continue to pass up to Django 2.2/Python 3.7. Is it fair to say that these versions should be supported as well? If so here's the PR to update the build matrix :).

Please let me know if any questions or if I can adjust anything!