### PR TITLE
Added timesince to notifications list API route

### DIFF
--- a/notifications/views.py
+++ b/notifications/views.py
@@ -231,6 +231,7 @@ def live_all_notification_list(request):
             struct['action_object'] = str(notification.action_object)
         if notification.data:
             struct['data'] = notification.data
+        struct['timesince'] = notification.timesince()
         all_list.append(struct)
         if request.GET.get('mark_as_read'):
             notification.mark_as_read()


### PR DESCRIPTION
`timesince()` is not in the API `struct` as it is a method.  

Django does this well, and avoids the use of another javascript library to render this properly client side.