### PR TITLE
Add custom column for extra data

### DIFF
--- a/notifications/base/models.py
+++ b/notifications/base/models.py
@@ -301,6 +301,10 @@ def notify_handler(verb, **kwargs):
                         ContentType.objects.get_for_model(obj))
 
         if kwargs and EXTRA_DATA:
+            # set kwargs as model column if available
+            for key in list(kwargs.keys()):
+                if hasattr(newnotify, key):
+                    setattr(newnotify, key, kwargs.pop(key))
             newnotify.data = kwargs
 
         newnotify.save()

--- a/notifications/tests/sample_notifications/tests.py
+++ b/notifications/tests/sample_notifications/tests.py
@@ -2,6 +2,9 @@ import os
 from unittest import skipUnless
 
 import swapper
+from django.contrib.auth.models import User
+
+from notifications.signals import notify
 from notifications.tests.tests import AdminTest as BaseAdminTest
 from notifications.tests.tests import NotificationTest as BaseNotificationTest
 
@@ -20,3 +23,24 @@ class AdminTest(BaseAdminTest):
 @skipUnless(os.environ.get('SAMPLE_APP', False), 'Running tests on standard django-notifications models')
 class NotificationTest(BaseNotificationTest):
     pass
+
+
+class TestExtraDataCustomAccessor(NotificationTest):
+    def setUp(self):
+        self.from_user = User.objects.create_user(username="from_extra", password="pwd", email="example@example.com")
+        self.to_user = User.objects.create_user(username="to_extra", password="pwd", email="example@example.com")
+        notify.send(
+            self.from_user,
+            recipient=self.to_user,
+            verb='commented',
+            action_object=self.from_user,
+            url="/learn/ask-a-pro/q/test-question-9/299/",
+            other_content="Hello my 'world'",
+            details="test detail"
+        )
+
+    def test_extra_data(self):
+        notification = Notification.objects.get(details="test detail")
+        assert notification, "Expected a notification retrieved by custom extra data accessor"
+        assert notification.details == "test detail", "Custom accessor should return set value"
+        assert "details" not in notification.data, "Custom accessor should not be in json data"


### PR DESCRIPTION
Through this PR, adding extra data will check every key given for the existence of a column on the notification model before filling the `data` column.

- [x] notify handler
- [x] tests
- [ ] docs
- [ ] setting to specifically enable / disable this behavior?
- [ ] metadata property limiting the allowed keys to "dynamically" set?
