### PR TITLE
Feature/search fields on notifications admin

### DIFF
--- a/notifications/admin.py
+++ b/notifications/admin.py
@@ -8,14 +8,7 @@ Notification = load_model('notifications', 'Notification')
 
 
 class NotificationAdmin(AbstractNotificationAdmin):
-    raw_id_fields = ('recipient',)
-    list_display = ('recipient', 'actor',
-                    'level', 'target', 'unread', 'public')
-    list_filter = ('level', 'unread', 'public', 'timestamp',)
-
-    def get_queryset(self, request):
-        qs = super(NotificationAdmin, self).get_queryset(request)
-        return qs.prefetch_related('actor')
+    pass
 
 
 admin.site.register(Notification, NotificationAdmin)

--- a/notifications/base/admin.py
+++ b/notifications/base/admin.py
@@ -6,7 +6,8 @@ class AbstractNotificationAdmin(admin.ModelAdmin):
     list_display = ('recipient', 'actor',
                     'level', 'target', 'unread', 'public')
     list_filter = ('level', 'unread', 'public', 'timestamp',)
+    search_fields = ('recipient__email', 'id',)
 
     def get_queryset(self, request):
-        qs = super(AbstractNotificationAdmin, self).get_queryset(request)
+        qs = super().get_queryset(request)
         return qs.prefetch_related('actor')


### PR DESCRIPTION
First, thanks for maintaining django-notifications!

As a user I'd like to be able to find notifications for a particular user or find a particular notification by it's ID. This adds that functionality via `search_fields` to the admin.

Hoping this is a welcome change, and let me know if I can make any adjustments! Thank you again!