### PR TITLE
Assign copy of kwargs instead of direct reference

### DIFF
--- a/notifications/base/models.py
+++ b/notifications/base/models.py
@@ -301,7 +301,7 @@ def notify_handler(verb, **kwargs):
                         ContentType.objects.get_for_model(obj))
 
         if kwargs and EXTRA_DATA:
-            newnotify.data = kwargs
+            newnotify.data = kwargs.copy()
 
         newnotify.save()
         new_notifications.append(newnotify)


### PR DESCRIPTION
Make a shallow copy of kwargs and assign it to the data attribute. 
It allows overriding the save method of the model and modification of data if needed.