### PR TITLE
[feat] add caching and a setting CACHE_TIMEOUT to configure the timeout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,9 @@ Changelog
 =========
 
 
+- new setting 'CACHE_TIMEOUT' to cache certain result such as "notifications.unread().count".
+  (a timeout value of 0 won’t cache anything).
+
 1.7.0
 -----
 

--- a/notifications/settings.py
+++ b/notifications/settings.py
@@ -8,6 +8,7 @@ CONFIG_DEFAULTS = {
     'USE_JSONFIELD': False,
     'SOFT_DELETE': False,
     'NUM_TO_FETCH': 10,
+    'CACHE_TIMEOUT': 2,
 }
 
 


### PR DESCRIPTION
Add a new setting 'CACHE_TIMEOUT' to cache certain result such as "notifications.unread().count". (a timeout value of 0 won’t cache anything).