### PR TITLE
fix: 🚑️ distutils deprecation

### DIFF
--- a/notifications/base/models.py
+++ b/notifications/base/models.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-many-lines
-from distutils.version import \
-    StrictVersion  # pylint: disable=no-name-in-module,import-error
-
 from django import get_version
 from django.conf import settings
 from django.contrib.auth.models import Group
@@ -11,27 +8,33 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.query import QuerySet
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
 from django.utils.html import format_html
-
+from django.utils.translation import gettext_lazy as _
 from jsonfield.fields import JSONField
 from model_utils import Choices
+from packaging.version import (
+    parse as parse_version,  # pylint: disable=no-name-in-module,import-error
+)
+from swapper import load_model
+
 from notifications import settings as notifications_settings
 from notifications.signals import notify
 from notifications.utils import id2slug
-from swapper import load_model
 
-if StrictVersion(get_version()) >= StrictVersion('1.8.0'):
+if parse_version(get_version()) >= parse_version('1.8.0'):
     from django.contrib.contenttypes.fields import GenericForeignKey  # noqa
 else:
     from django.contrib.contenttypes.generic import GenericForeignKey  # noqa
 
 try:
     # Django >= 1.7
-    from django.urls import reverse, NoReverseMatch
+    from django.urls import NoReverseMatch, reverse
 except ImportError:
     # Django <= 1.6
-    from django.core.urlresolvers import reverse, NoReverseMatch  # pylint: disable=no-name-in-module,import-error
+    from django.core.urlresolvers import (  # pylint: disable=no-name-in-module,import-error
+        NoReverseMatch,
+        reverse,
+    )
 
 EXTRA_DATA = notifications_settings.get_config()['USE_JSONFIELD']
 

--- a/notifications/templatetags/notifications_tags.py
+++ b/notifications/templatetags/notifications_tags.py
@@ -1,18 +1,22 @@
 ''' Django notifications template tags file '''
 # -*- coding: utf-8 -*-
-from distutils.version import StrictVersion  # pylint: disable=no-name-in-module,import-error
-
 from django import get_version
+from django.core.cache import cache
 from django.template import Library
 from django.utils.html import format_html
-from django.core.cache import cache
+from packaging.version import (
+    parse as parse_version,  # pylint: disable=no-name-in-module,import-error
+)
+
 from notifications import settings
 from notifications.settings import get_config
 
 try:
     from django.urls import reverse
 except ImportError:
-    from django.core.urlresolvers import reverse  # pylint: disable=no-name-in-module,import-error
+    from django.core.urlresolvers import (
+        reverse,  # pylint: disable=no-name-in-module,import-error
+    )
 
 register = Library()
 
@@ -32,7 +36,7 @@ def notifications_unread(context):
     return get_cached_notification_unread_count(user)
 
 
-if StrictVersion(get_version()) >= StrictVersion('2.0'):
+if parse_version(get_version()) >= parse_version('2.0'):
     notifications_unread = register.simple_tag(takes_context=True)(notifications_unread)  # pylint: disable=invalid-name
 else:
     notifications_unread = register.assignment_tag(takes_context=True)(notifications_unread)  # noqa

--- a/notifications/tests/urls.py
+++ b/notifications/tests/urls.py
@@ -1,15 +1,19 @@
 ''' Django notification urls for tests '''
 # -*- coding: utf-8 -*-
-from distutils.version import StrictVersion  # pylint: disable=no-name-in-module,import-error
-
 from django import get_version
 from django.contrib import admin
-from notifications.tests.views import (live_tester,  # pylint: disable=no-name-in-module,import-error
-                                       make_notification)
+from packaging.version import (
+    parse as parse_version,  # pylint: disable=no-name-in-module,import-error
+)
 
-if StrictVersion(get_version()) >= StrictVersion('2.1'):
-    from django.urls import include, path  # noqa
+from notifications.tests.views import (
+    live_tester,  # pylint: disable=no-name-in-module,import-error
+)
+from notifications.tests.views import make_notification
+
+if parse_version(get_version()) >= parse_version('2.1'):
     from django.contrib.auth.views import LoginView
+    from django.urls import include, path  # noqa
     urlpatterns = [
         path('test_make/', make_notification),
         path('test/', live_tester),
@@ -17,9 +21,9 @@ if StrictVersion(get_version()) >= StrictVersion('2.1'):
         path('admin/', admin.site.urls),
         path('', include('notifications.urls', namespace='notifications')),
     ]
-elif StrictVersion(get_version()) >= StrictVersion('2.0') and StrictVersion(get_version()) < StrictVersion('2.1'):
-    from django.urls import include, path  # noqa
+elif parse_version(get_version()) >= parse_version('2.0') and parse_version(get_version()) < parse_version('2.1'):
     from django.contrib.auth.views import login
+    from django.urls import include, path  # noqa
     urlpatterns = [
         path('test_make/', make_notification),
         path('test/', live_tester),

--- a/notifications/urls.py
+++ b/notifications/urls.py
@@ -1,12 +1,13 @@
 ''' Django notification urls file '''
 # -*- coding: utf-8 -*-
-from distutils.version import StrictVersion  # pylint: disable=no-name-in-module,import-error
-
 from django import get_version
+from packaging.version import (
+    parse as parse_version,  # pylint: disable=no-name-in-module,import-error
+)
 
 from . import views
 
-if StrictVersion(get_version()) >= StrictVersion('2.0'):
+if parse_version(get_version()) >= parse_version('2.0'):
     from django.urls import re_path as pattern
 else:
     from django.conf.urls import url as pattern

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 ''' Django Notifications example views '''
-from distutils.version import \
-    StrictVersion  # pylint: disable=no-name-in-module,import-error
-
 from django import get_version
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
@@ -12,6 +9,9 @@ from django.utils.encoding import iri_to_uri
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.cache import never_cache
 from django.views.generic import ListView
+from packaging.version import (
+    parse as parse_version,  # pylint: disable=no-name-in-module,import-error
+)
 from swapper import load_model
 
 from notifications import settings as notification_settings
@@ -20,7 +20,7 @@ from notifications.utils import slug2id
 
 Notification = load_model('notifications', 'Notification')
 
-if StrictVersion(get_version()) >= StrictVersion('1.7.0'):
+if parse_version(get_version()) >= parse_version('1.7.0'):
     from django.http import JsonResponse  # noqa
 else:
     # Django 1.6 doesn't have a proper JsonResponse

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(
         'django-model-utils>=3.1.0',
         'jsonfield>=2.1.0',
         'pytz',
-        'swapper'
+        'swapper',
+        "packaging"
     ],
     test_requires=[
         'django>=3.2',


### PR DESCRIPTION
This PR uses `packaging.version.parse` instead of `distutils` which is deprecated in Python 3.12.