### PR TITLE
Update README.md to reflect new import style for notification URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,12 @@ INSTALLED_APPS = (
 Add the notifications urls to your urlconf:
 
 ```python
-import notifications.urls
-
 urlpatterns = [
     ...
-    url('^inbox/notifications/', include(notifications.urls, namespace='notifications')),
+    path('inbox/notifications/', include("notifications.urls", namespace='notifications')),
     ...
 ]
 ```
-
-The method of installing these urls, importing rather than using
-`'notifications.urls'`, is required to ensure that the urls are
-installed in the `notifications` namespace.
 
 To run schema migration, execute
 `python manage.py migrate notifications`.
@@ -261,7 +255,7 @@ Mark the current object as read.
 
 ### Template tags
 
-Put `{% load notifications\_tags %}` in the template before
+Put `{% load notifications_tags %}` in the template before
 you actually use notification tags.
 
 ### `notifications_unread`

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Add the notifications urls to your urlconf:
 ```python
 urlpatterns = [
     ...
-    path('inbox/notifications/', include("notifications.urls", namespace='notifications')),
+    path('inbox/notifications/', include('notifications.urls', namespace='notifications')),
     ...
 ]
 ```


### PR DESCRIPTION
- Switched from `url` to `path` for including notification URLs in examples
- Removed redundant import statement for `notifications.urls`
- Corrected template tag name in the documentation