### PR TITLE
Added Django versions to tox test matrix and updated GitHub action versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,23 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        django-version: ["42", "50", "51", "52"]
+        exclude:
+          - python-version: '3.9'
+            django-version: 50
+          - python-version: '3.9'
+            django-version: 51
+          - python-version: '3.9'
+            django-version: 52
       fail-fast: false
+
 
     steps:
       - name: apt update
         run: sudo apt update
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }} & Django ${{ matrix.django-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -32,4 +41,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install tox tox-gh-actions
       - name: Test with tox
-        run: tox -v
+        env:
+          TOXENV: django${{ matrix.django-version }}
+        run: tox


### PR DESCRIPTION
Hi there!

I added the Django versions to the test matrix to ensure that the package keeps it's promises regarding supported Django versions.

Furthermore, I updated deprecated GitHub actions.

---

We use this package and have a conflict with Django 4.2, therefore I think it's a big benefit to have a test matix covering django and python versions. Once this is merged, I'll activate Django 4.2 and see what the pipeline has to say about compatability 🙂 

Best from Cologne  
Ronny