### PR TITLE
Fix issue where only the first recipient would receive a Notification…

### DIFF
--- a/notifications/base/models.py
+++ b/notifications/base/models.py
@@ -357,11 +357,12 @@ def notify_handler(verb, **kwargs):
                         ContentType.objects.get_for_model(obj, for_concrete_model=for_concrete_model))
 
         if kwargs and EXTRA_DATA:
+            kwargs_copy = kwargs.copy()  # Make sure every recipient has the same kwargs
             # set kwargs as model column if available
             for key in list(kwargs.keys()):
                 if hasattr(newnotify, key):
-                    setattr(newnotify, key, kwargs.pop(key))
-            newnotify.data = kwargs
+                    setattr(newnotify, key, kwargs_copy.pop(key))
+            newnotify.data = kwargs_copy
 
         newnotify.save()
         new_notifications.append(newnotify)


### PR DESCRIPTION
… with all kwargs if multiple recipients were specified

Ran into this issue on a project of mine. Essentially, if the `Notification` model is extended, additional fields are passed as kwargs when signaling, and multiple recipients are specified, only the first recipient would receive all the kwargs.

Example code:
```
class Notification(AbstractNotification):
    my_field = models.CharField()

sender = user_1
notification_recipients = [user_2, user_3]
notify.send(
    sender=user_1,
    recipient=notification_recipients,
    my_field='my field value`,
)
```

In this scenario, only `user_2` would have `my field value` as the value for `my_field` on their Notification.

P.S. Great library, I looked around for a contribution guide but couldn't find anything. Let me know if I need to make any adjustments!