### PR TITLE
Add compatibility with Python 3.12

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -39,4 +39,4 @@ fay (https://github.com/fay)
 blag (https://github.com/blag)
 Zhongyuan Zhang (https://github.com/zhang-z)
 Samuel Spencer (https://github.com/LegoStormtroopr)
-
+Karolis Ryselis (https://github.com/esperonus-karolis)

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Spec: <http://activitystrea.ms/specs/atom/1.0/>
 
 ## Requirements
 
--   Python 3.7, 3.8, 3.9, 3.10, 3.11
--   Django 3.2, 4.0, 4.1
+-   Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12
+-   Django 3.2, 4.0, 4.1, 4.2
 
 ## Installation
 

--- a/notifications/base/models.py
+++ b/notifications/base/models.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-many-lines
-from distutils.version import \
-    StrictVersion  # pylint: disable=no-name-in-module,import-error
-
-from django import get_version
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
@@ -21,10 +17,7 @@ from notifications.signals import notify
 from notifications.utils import id2slug
 from swapper import load_model
 
-if StrictVersion(get_version()) >= StrictVersion('1.8.0'):
-    from django.contrib.contenttypes.fields import GenericForeignKey  # noqa
-else:
-    from django.contrib.contenttypes.generic import GenericForeignKey  # noqa
+from django.contrib.contenttypes.fields import GenericForeignKey  # noqa
 
 try:
     # Django >= 1.7

--- a/notifications/templatetags/notifications_tags.py
+++ b/notifications/templatetags/notifications_tags.py
@@ -1,13 +1,11 @@
 ''' Django notifications template tags file '''
 # -*- coding: utf-8 -*-
-from distutils.version import StrictVersion  # pylint: disable=no-name-in-module,import-error
 
-from django import get_version
+from django.core.cache import cache
 from django.template import Library
 from django.utils.html import format_html
-from django.core.cache import cache
+
 from notifications import settings
-from notifications.settings import get_config
 
 try:
     from django.urls import reverse
@@ -32,10 +30,7 @@ def notifications_unread(context):
     return get_cached_notification_unread_count(user)
 
 
-if StrictVersion(get_version()) >= StrictVersion('2.0'):
-    notifications_unread = register.simple_tag(takes_context=True)(notifications_unread)  # pylint: disable=invalid-name
-else:
-    notifications_unread = register.assignment_tag(takes_context=True)(notifications_unread)  # noqa
+notifications_unread = register.simple_tag(takes_context=True)(notifications_unread)  # pylint: disable=invalid-name
 
 
 @register.filter

--- a/notifications/tests/urls.py
+++ b/notifications/tests/urls.py
@@ -1,39 +1,17 @@
 ''' Django notification urls for tests '''
 # -*- coding: utf-8 -*-
-from distutils.version import StrictVersion  # pylint: disable=no-name-in-module,import-error
 
-from django import get_version
 from django.contrib import admin
+from django.contrib.auth.views import LoginView
+from django.urls import include, path  # noqa
+
 from notifications.tests.views import (live_tester,  # pylint: disable=no-name-in-module,import-error
                                        make_notification)
 
-if StrictVersion(get_version()) >= StrictVersion('2.1'):
-    from django.urls import include, path  # noqa
-    from django.contrib.auth.views import LoginView
-    urlpatterns = [
-        path('test_make/', make_notification),
-        path('test/', live_tester),
-        path('login/', LoginView.as_view(), name='login'),  # reverse for django login is not working
-        path('admin/', admin.site.urls),
-        path('', include('notifications.urls', namespace='notifications')),
-    ]
-elif StrictVersion(get_version()) >= StrictVersion('2.0') and StrictVersion(get_version()) < StrictVersion('2.1'):
-    from django.urls import include, path  # noqa
-    from django.contrib.auth.views import login
-    urlpatterns = [
-        path('test_make/', make_notification),
-        path('test/', live_tester),
-        path('login/', login, name='login'),  # reverse for django login is not working
-        path('admin/', admin.site.urls),
-        path('', include('notifications.urls', namespace='notifications')),
-    ]
-else:
-    from django.conf.urls import include, url
-    from django.contrib.auth.views import login
-    urlpatterns = [
-        url(r'^login/$', login, name='login'),  # reverse for django login is not working
-        url(r'^test_make/', make_notification),
-        url(r'^test/', live_tester),
-        url(r'^', include('notifications.urls', namespace='notifications')),
-        url(r'^admin/', admin.site.urls),
-    ]
+urlpatterns = [
+    path('test_make/', make_notification),
+    path('test/', live_tester),
+    path('login/', LoginView.as_view(), name='login'),  # reverse for django login is not working
+    path('admin/', admin.site.urls),
+    path('', include('notifications.urls', namespace='notifications')),
+]

--- a/notifications/urls.py
+++ b/notifications/urls.py
@@ -1,16 +1,9 @@
 ''' Django notification urls file '''
 # -*- coding: utf-8 -*-
-from distutils.version import StrictVersion  # pylint: disable=no-name-in-module,import-error
 
-from django import get_version
+from django.urls import re_path as pattern
 
 from . import views
-
-if StrictVersion(get_version()) >= StrictVersion('2.0'):
-    from django.urls import re_path as pattern
-else:
-    from django.conf.urls import url as pattern
-
 
 urlpatterns = [
     pattern(r'^$', views.AllNotificationsList.as_view(), name='all'),

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 ''' Django Notifications example views '''
-from distutils.version import \
-    StrictVersion  # pylint: disable=no-name-in-module,import-error
 
-from django import get_version
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, redirect
@@ -20,21 +17,7 @@ from notifications.utils import slug2id
 
 Notification = load_model('notifications', 'Notification')
 
-if StrictVersion(get_version()) >= StrictVersion('1.7.0'):
-    from django.http import JsonResponse  # noqa
-else:
-    # Django 1.6 doesn't have a proper JsonResponse
-    import json
-
-    from django.http import HttpResponse  # noqa
-
-    def date_handler(obj):
-        return obj.isoformat() if hasattr(obj, 'isoformat') else obj
-
-    def JsonResponse(data):  # noqa
-        return HttpResponse(
-            json.dumps(data, default=date_handler),
-            content_type="application/json")
+from django.http import JsonResponse  # noqa
 
 
 class NotificationViewList(ListView):

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
+        'Framework :: Django :: 4.2',
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python',
@@ -66,6 +67,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Utilities'
     ],
     keywords='django notifications github action event stream',

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py{37,38,39,310,311}-django32
     py{38,39,310}-django40
     py{38,39,310,311}-django41
+    py{312}-django42
 
 [gh-actions]
 python =
@@ -12,6 +13,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 commands =
@@ -21,3 +23,4 @@ deps =
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<5.0


### PR DESCRIPTION
The only issue is the usage of distutils package. The only reason for using it is checking for legacy Django versions that are not supported anyway (as of pull request the oldest supported DJango version is 3.2). Removed the checks, added Python 3.12 and Django 4.2 to test matrix, updated docs.