### PR TITLE
fix(deps): patch notifications model for Django 5.1.6 compatibility

### DIFF
--- a/notifications/base/models.py
+++ b/notifications/base/models.py
@@ -237,7 +237,9 @@ class AbstractNotification(models.Model):
         abstract = True
         ordering = ('-timestamp',)
         # speed up notifications count query
-        index_together = ('recipient', 'unread')
+        indexes = [
+        models.Index(fields=['recipient', 'unread'])
+        ]
         verbose_name = _('Notification')
         verbose_name_plural = _('Notifications')
 


### PR DESCRIPTION
Add database index on ('recipient', 'unread') to Notification model  
to maintain compatibility with Django 5.1.6. This replaces the  
previous individual indexes to match Django 5's index handling  
requirements while preserving query performance optimizations.  