### PR TITLE
docs: add pointer to community fork in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![build-status](https://travis-ci.org/django-notifications/django-notifications.svg)](https://travis-ci.org/django-notifications/django-notifications)
 [![Coverage Status](https://coveralls.io/repos/github/django-notifications/django-notifications/badge.svg?branch=master)](https://coveralls.io/github/django-notifications/django-notifications?branch=master)
 
+> [!IMPORTANT]
+> This project is not currently maintained. For an actively maintained drop-in replacement, see the [community fork](#community-fork) below.
 
 [django-notifications](https://github.com/django-notifications/django-notifications) is a GitHub notification alike app for Django, it was derived from [django-activity-stream](https://github.com/justquick/django-activity-stream)
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Spec: <http://activitystrea.ms/specs/atom/1.0/>
 ## Community fork
 
 A community-maintained fork is available at
-[django-notifications-community](https://github.com/django-notifications-community),
+[django-notifications-community](https://github.com/django-notifications-community/django-notifications-community),
 published on PyPI as `django-notifications-community`. It is a drop-in
 replacement with the same package layout and APIs. See
 [issue #416](https://github.com/django-notifications/django-notifications/issues/416)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ is backward-compatible (except dropping support for Python 3.9), with only
 migrations required during upgrade. Python 3.9 users can pin
 `django-notifications-community<1.10`.
 
+---
+
 [django-notifications](https://github.com/django-notifications/django-notifications) is a GitHub notification alike app for Django, it was derived from [django-activity-stream](https://github.com/justquick/django-activity-stream)
 
 The major difference between `django-notifications` and `django-activity-stream`:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@
 > [!IMPORTANT]
 > This project is not currently maintained. For an actively maintained drop-in replacement, see the [community fork](#community-fork) below.
 
+## Community fork
+
+A community-maintained fork is available at
+[django-notifications-community](https://github.com/django-notifications-community/django-notifications-community),
+published on PyPI as `django-notifications-community`. It is a drop-in
+replacement with the same package layout and APIs. See
+[issue #416](https://github.com/django-notifications/django-notifications/issues/416)
+for context.
+[v1.10.0](https://github.com/django-notifications-community/django-notifications-community/releases/tag/v1.10.0)
+is backward-compatible (except dropping support for Python 3.9), with only
+migrations required during upgrade. Python 3.9 users can pin
+`django-notifications-community<1.10`.
+
 [django-notifications](https://github.com/django-notifications/django-notifications) is a GitHub notification alike app for Django, it was derived from [django-activity-stream](https://github.com/justquick/django-activity-stream)
 
 The major difference between `django-notifications` and `django-activity-stream`:
@@ -37,19 +50,6 @@ For example: [justquick](https://github.com/justquick/) `(actor)`
 
 Nomenclature of this specification is based on the Activity Streams
 Spec: <http://activitystrea.ms/specs/atom/1.0/>
-
-## Community fork
-
-A community-maintained fork is available at
-[django-notifications-community](https://github.com/django-notifications-community/django-notifications-community),
-published on PyPI as `django-notifications-community`. It is a drop-in
-replacement with the same package layout and APIs. See
-[issue #416](https://github.com/django-notifications/django-notifications/issues/416)
-for context.
-[v1.10.0](https://github.com/django-notifications-community/django-notifications-community/releases/tag/v1.10.0)
-is backward-compatible (except dropping support for Python 3.9), with only
-migrations required during upgrade. Python 3.9 users can pin
-`django-notifications-community<1.10`.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/django-notifications/django-notifications/badge.svg?branch=master)](https://coveralls.io/github/django-notifications/django-notifications?branch=master)
 
 > [!IMPORTANT]
-> This project is not currently maintained. For an actively maintained drop-in replacement, see the [community fork](#community-fork) below.
+> This project is not currently maintained. For an actively maintained drop-in replacement, see the [community fork](#community-fork).
 
 ## Community fork
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ For example: [justquick](https://github.com/justquick/) `(actor)`
 Nomenclature of this specification is based on the Activity Streams
 Spec: <http://activitystrea.ms/specs/atom/1.0/>
 
+## Community fork
+
+A community-maintained fork is available at
+[django-notifications-community](https://github.com/django-notifications-community),
+published on PyPI as `django-notifications-community`. It is a drop-in
+replacement with the same package layout and APIs. See
+[issue #416](https://github.com/django-notifications/django-notifications/issues/416)
+for context.
+[v1.10.0](https://github.com/django-notifications-community/django-notifications-community/releases/tag/v1.10.0)
+is backward-compatible (except dropping support for Python 3.9), with only
+migrations required during upgrade.
+
 ## Requirements
 
 -   Python 3.9, 3.10, 3.11, 3.12, 3.13

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ replacement with the same package layout and APIs. See
 for context.
 [v1.10.0](https://github.com/django-notifications-community/django-notifications-community/releases/tag/v1.10.0)
 is backward-compatible (except dropping support for Python 3.9), with only
-migrations required during upgrade.
+migrations required during upgrade. Python 3.9 users can pin
+`django-notifications-community<1.10`.
 
 ## Requirements
 


### PR DESCRIPTION
Adds a short pointer in the README to the community fork at django-notifications-community, for users tracking issue #416. Purely informational — the fork is BSD-3 identical to upstream and preserves all original copyrights.

@nemesifier — I reached out by email and you mentioned stepping back from the project; this is the small follow-up we discussed. Happy to revise wording or close if anything doesn't sit right.